### PR TITLE
Level 2: Model for Restaurants + updates/improvements to existing models

### DIFF
--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,7 +1,8 @@
 class Menu < ApplicationRecord
   enum menu_type: %i(breakfast lunch dinner beverage brunch special).map{ |sym| [sym, sym.to_s] }.to_h
 
-  has_many :menu_items
+  belongs_to :restaurant
+  has_and_belongs_to_many :menu_items
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :menu_type, presence: true

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,14 +1,22 @@
 class MenuItem < ApplicationRecord
-  belongs_to :menu
+  has_and_belongs_to_many :menus
 
-  validates :name, presence: true, length: { maximum: 50 }
+  validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
   validates :price, numericality: { greater_than_or_equal_to: 0 }
 
   def price_s
     str = price.to_s
-    decimal_index = str.length == 1 ? 0 : -3
-    str.insert(decimal_index, '.')
-    str.insert(0, '$')
+    if str.length == 1
+      str.insert(0, '$0.0')
+    elsif str.length == 2
+      str.insert(-3, '.')
+      str.insert(0, '$0')
+    else
+      str.insert(-3, '.')
+      str.insert(0, '$')
+    end
+
+    str
   end
 end
 

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,0 +1,6 @@
+class Restaurant < ApplicationRecord
+  has_many :menus
+
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :address, presence: true
+end

--- a/db/migrate/20211215201625_create_restaurants.rb
+++ b/db/migrate/20211215201625_create_restaurants.rb
@@ -1,0 +1,9 @@
+class CreateRestaurants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :restaurants do |t|
+      t.timestamps
+      t.string :name, limit: 50, null: false
+      t.text :address, null: false
+    end
+  end
+end

--- a/db/migrate/20211215202024_add_restaurant_to_menus.rb
+++ b/db/migrate/20211215202024_add_restaurant_to_menus.rb
@@ -1,0 +1,5 @@
+class AddRestaurantToMenus < ActiveRecord::Migration[6.1]
+  def change
+    add_belongs_to :menus, :restaurant, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20211215202133_make_menu_items_habtm_menus.rb
+++ b/db/migrate/20211215202133_make_menu_items_habtm_menus.rb
@@ -1,0 +1,7 @@
+class MakeMenuItemsHabtmMenus < ActiveRecord::Migration[6.1]
+  def change
+    create_join_table :menus, :menu_items
+    remove_belongs_to :menu_items, :menu, null: false, foreign_key: true
+    add_index :menu_items, :name, unique: true
+  end
+end

--- a/db/migrate/20211216014024_add_price_constraint_to_menu_items.rb
+++ b/db/migrate/20211216014024_add_price_constraint_to_menu_items.rb
@@ -1,0 +1,5 @@
+class AddPriceConstraintToMenuItems < ActiveRecord::Migration[6.1]
+  def change
+    add_check_constraint :menu_items, 'price >= 0'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_13_150044) do
+ActiveRecord::Schema.define(version: 2021_12_16_014024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,16 +18,28 @@ ActiveRecord::Schema.define(version: 2021_12_13_150044) do
   create_table "menu_items", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "menu_id", null: false
     t.string "name", limit: 50, null: false
     t.integer "price", null: false
     t.text "description"
     t.boolean "highlighted", default: false, null: false
-    t.index ["menu_id"], name: "index_menu_items_on_menu_id"
+    t.index ["name"], name: "index_menu_items_on_name", unique: true
+    t.check_constraint "price >= 0"
+  end
+
+  create_table "menu_items_menus", id: false, force: :cascade do |t|
+    t.bigint "menu_id", null: false
+    t.bigint "menu_item_id", null: false
   end
 
 # Could not dump table "menus" because of following StandardError
 #   Unknown type 't_menu_type' for column 'menu_type'
 
-  add_foreign_key "menu_items", "menus"
+  create_table "restaurants", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name", limit: 50, null: false
+    t.text "address", null: false
+  end
+
+  add_foreign_key "menus", "restaurants"
 end

--- a/spec/db/menu_item_spec.rb
+++ b/spec/db/menu_item_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'MenuItem' do
+  before(:all) do
+    res = Restaurant.create(name: 'Franklin Barbecue', address: '900 E 11th St, Austin, TX 78702')
+    @menu = res.menus.create(name: 'Main Menu', menu_type: 'lunch')
+    @menu.menu_items.create(name: 'Brisket (1lb)', price: 2000)
+  end
+
+  it 'does not allow duplicate names' do
+    @menu.menu_items.create(name: 'Brisket (1lb)', price: 2000)
+
+    expect(@menu).not_to be_valid
+  end
+end
+

--- a/spec/db/menu_spec.rb
+++ b/spec/db/menu_spec.rb
@@ -4,7 +4,8 @@ describe 'example menus' do
 
   describe 'breakfast menu' do
     before(:all) do
-      @menu = Menu.create(name: "Stacks Breakfast Fixin's", menu_type: 'breakfast')
+      res = Restaurant.create(name: 'Stacks', address: '139 E Campbell Ave, Campbell, CA 95008')
+      @menu = Menu.create(restaurant: res, name: "Stacks Breakfast Fixin's", menu_type: 'breakfast')
       @menu.menu_items.create(name: 'Oreo Pancake Short Stack', price: 500)
       @menu.menu_items.create(name: 'Oreo Pancake Full Stack', price: 600, highlighted: true)
       @menu.menu_items.create(name: 'Denver Omelette', price: 700, highlighted: true)
@@ -20,7 +21,7 @@ describe 'example menus' do
     it 'has the menu accessible from the item' do
       item = MenuItem.find_by(name: 'Biscuits & Gravy')
 
-      expect(item.menu).to eq(@menu)
+      expect(item.menus.first).to eq(@menu)
     end
 
     it 'has highlights' do
@@ -53,5 +54,7 @@ describe 'example menus' do
       expect(@menu.menu_items.order(:name).pluck(:name)).to eq(expected_result)
     end
   end
+
+  describe 'brunch restaurant with multiple menus with shared items'
 end
 

--- a/spec/db/restaurant_spec.rb
+++ b/spec/db/restaurant_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe 'brunch joint' do
+  before(:all) do
+    @res = Restaurant.create(name: 'Cloverleaf South', address: '325 E Winslow Rd, Bloomington, IN 47401')
+
+    @breakfast_menu = @res.menus.create(name: 'Breakfast (5:00am-11:00am M-F)', menu_type: 'breakfast')
+    @breakfast_menu.menu_items.create(name: 'Pancake Short Stack', price: 300)
+    @breakfast_menu.menu_items.create(name: 'Pancake Full Stack', price: 400)
+    @breakfast_menu.menu_items.create(name: 'Eggs Benedict', price: 700, highlighted: true)
+    @breakfast_menu.menu_items.create(name: 'Country Fried Steak & Eggs', price: 900, highlighted: true)
+    @breakfast_menu.menu_items.create(name: 'Biscuits & Gravy', price: 350)
+    @breakfast_menu.menu_items.create(name: 'Coffee', price: 100)
+    @breakfast_menu.menu_items.create(name: 'Bacon Slices (2)', price: 75)
+
+    @lunch_menu = @res.menus.create(name: 'Lunch (11:00am-2:00pm M-F)', menu_type: 'lunch')
+    @lunch_menu.menu_items.create(name: 'Turkey Club', price: 500)
+    @lunch_menu.menu_items.create(name: 'Caesar Salad', price: 500, highlighted: true)
+    @lunch_menu.menu_items.create(name: 'Double Cheeseburger', price: 650, highlighted: true)
+    @lunch_menu.menu_items.create(name: 'Pork Tenderloin', price: 800, highlighted: true)
+    @lunch_menu.menu_items.create(name: 'French Fries', price: 425)
+    @lunch_menu.menu_items.create(name: 'Coca-Cola', price: 100)
+    @lunch_menu.menu_items.create(name: 'Side of Ranch', price: 10)
+
+    @brunch_menu = @res.menus.create(name: 'Brunch (8:00am-2:00pm Weekends)', menu_type: 'brunch')
+    @brunch_menu.menu_items = @breakfast_menu.menu_items + @lunch_menu.menu_items
+  end
+
+  it 'has a breakfast menu' do
+    expect(@res.menus.find_by(menu_type: 'breakfast')).to eq(@breakfast_menu)
+  end
+
+  it 'has a lunch menu' do
+    expect(@res.menus.find_by(menu_type: 'lunch')).to eq(@lunch_menu)
+  end
+
+  it 'has a brunch menu' do
+    expect(@res.menus.find_by(menu_type: 'brunch')).to eq(@brunch_menu)
+  end
+
+  it 'has a brunch menu containing all items from both menus with no duplicates' do
+    breakfast_item_names = Set.new(@breakfast_menu.menu_items.pluck(:name))
+    lunch_item_names = Set.new(@lunch_menu.menu_items.pluck(:name))
+
+    expect(breakfast_item_names.size + lunch_item_names.size).to eq(@brunch_menu.menu_items.size)
+   
+    brunch_item_names = Set.new(@brunch_menu.menu_items.pluck(:name))
+    expect(breakfast_item_names + lunch_item_names).to eq(brunch_item_names)
+  end
+end
+

--- a/spec/models/menu_item_spec.rb
+++ b/spec/models/menu_item_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 describe MenuItem do
 
-  let (:menu) { Menu.new(name: 'In-n-Out', menu_type: 'dinner') }
-  let (:menu_item) { MenuItem.new(menu: menu, name: 'Double-Double', price: 400) }
+  let(:restaurant) { Restaurant.new(name: 'Foobar', address: '756 Gerhold Stravenue, Suite 812, 13640, South Katrinaberg, Colorado, United States')  }
+  let(:menu) { Menu.new(restaurant: restaurant, name: 'In-n-Out', menu_type: 'dinner') }
+  let(:menu_item) { MenuItem.new(menus: [menu], name: 'Double-Double', price: 400) }
   
   it 'is valid with valid attributes' do
     expect(menu_item).to be_valid
   end
 
-  it 'is invalid when not part of a menu' do
-    menu_item.menu = nil
-
+  it 'may not have a negative price' do
+    menu_item.price = -100
+    
     expect(menu_item).not_to be_valid
   end
 
@@ -23,6 +24,38 @@ describe MenuItem do
 
   it 'is not highlighted by default' do
     expect(menu_item.highlighted).to be_falsey
+  end
+
+  describe 'MenuItem#price_s' do
+    it 'can format dollar amounts correctly' do
+      menu_item.price = 355
+
+      expect(menu_item.price_s).to eq('$3.55')
+    end
+    
+    it 'can format prices requiring one leading zero' do
+      menu_item.price = 55
+
+      expect(menu_item.price_s).to eq('$0.55')
+    end
+
+    it 'can format prices requiring two leading zeroes' do
+      menu_item.price = 5
+
+      expect(menu_item.price_s).to eq('$0.05')
+    end
+
+    it 'can format prices requiring one trailing zero' do
+      menu_item.price = 150
+
+      expect(menu_item.price_s).to eq('$1.50')
+    end
+
+    it 'can format prices requiring one leading and one trailing zero' do
+      menu_item.price = 50
+
+      expect(menu_item.price_s).to eq('$0.50')
+    end
   end
 end
 

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,26 +1,29 @@
 require 'rails_helper'
 
 describe Menu do
+  
+  let(:restaurant) { Restaurant.new(name: 'Foobar', address: '756 Gerhold Stravenue, Suite 812, 13640, South Katrinaberg, Colorado, United States')  }
+
   it 'is valid with valid attributes' do
-    menu = Menu.new(name: "Bub's Burgers", menu_type: 'dinner')
+    menu = Menu.new(restaurant: restaurant, name: "Bub's Burgers", menu_type: 'dinner')
 
     expect(menu).to be_valid
   end
 
   it 'is invalid with an overly long name' do
-    menu = Menu.new(name: 'a' * 51, menu_type: 'breakfast')
+    menu = Menu.new(restaurant: restaurant, name: 'a' * 51, menu_type: 'breakfast')
 
     expect(menu).not_to be_valid
   end
 
   it 'is invalid without a type' do
-    menu = Menu.new(name: 'Kurger Bing')
+    menu = Menu.new(restaurant: restaurant, name: 'Kurger Bing')
 
     expect(menu).not_to be_valid
   end
 
   it 'is invalid with a nonexistent type' do
-    expect{Menu.new(name: 'Chez Panisse', menu_type: 'wallet_shredder')}.to raise_error(ArgumentError)
+    expect{Menu.new(restaurant: restaurant, name: 'Chez Panisse', menu_type: 'wallet_shredder')}.to raise_error(ArgumentError)
   end
 end
 

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe Restaurant do
+  it 'is valid with valid attributes' do
+    res = Restaurant.new(name: 'Upland Brewing', address: '350 W 11th St, Bloomington, IN 47404')
+
+    expect(res).to be_valid
+  end
+
+  it 'is invalid with an overly long name' do
+    res = Restaurant.new(name: 'a' * 1000, address: '21 Jump Street, Beverly Hills, CA 90210')
+
+    expect(res).not_to be_valid
+  end
+
+  it 'is invalid without an address' do
+    res = Restaurant.new(name: 'Mr. Beast Burger')
+
+    expect(res).not_to be_valid
+  end
+
+  it 'is invalid without a name' do
+    res = Restaurant.new(address: '1234 Congress Ave, Austin, TX 78704')
+    
+    expect(res).not_to be_valid
+  end
+end


### PR DESCRIPTION
This introduces the "restaurant" model. A "restaurant" is the new
top-level object under this model, and can have many menus, which
can all have many items.

Furthermore, menu items are made unique by name and thus can be shared
across menus. This is demonstrated in a restaurant spec that has
separate breakfast and lunch menus, with a unified brunch menu for
weekends.

The whole suite also contains some improvements I missed in the first
round (e.g. automated tests for the price-to-string method in the
menu item model)